### PR TITLE
Codes related to using QFile::copy() is removed

### DIFF
--- a/unittests_cgnsfile/case_add_grid_and_result.cpp
+++ b/unittests_cgnsfile/case_add_grid_and_result.cpp
@@ -1,10 +1,6 @@
 #include "macros.h"
 
-#if defined(HAVE_QT)
-#include <QFile>
-#else
 #include "fs_copy.h"
-#endif
 
 #include <cgnslib.h>
 #include <iriclib.h>
@@ -20,11 +16,7 @@ extern "C" {
 
 void case_addGridAndResult()
 {
-#if defined(HAVE_QT)
-	QFile::copy("case_nogrid.cgn", "case_grid_result.cgn");
-#else
 	fs::copy("case_nogrid.cgn", "case_grid_result.cgn");
-#endif
 
 	int fid;
 	int ier = cg_open("case_grid_result.cgn", CG_MODE_MODIFY, &fid);

--- a/unittests_cgnsfile/case_bc.cpp
+++ b/unittests_cgnsfile/case_bc.cpp
@@ -1,10 +1,6 @@
 #include "macros.h"
 
-#if defined(HAVE_QT)
-#include <QFile>
-#else
 #include "fs_copy.h"
-#endif
 
 #include <cgnslib.h>
 #include <iriclib.h>
@@ -22,11 +18,7 @@ extern "C" {
 void case_BcRead()
 {
 	remove("case_bc.cgn");
-#if defined(HAVE_QT)
-	QFile::copy("case_init.cgn", "case_bc.cgn");
-#else
 	fs::copy("case_init.cgn", "case_bc.cgn");
-#endif
 
 	int fid;
 	int ier = cg_open("case_bc.cgn", CG_MODE_MODIFY, &fid);
@@ -193,11 +185,7 @@ void case_BcRead()
 
 void case_BcWrite()
 {
-#if defined(HAVE_QT)
-	QFile::copy("case_init.cgn", "case_bcwrite.cgn");
-#else
 	fs::copy("case_init.cgn", "case_bcwrite.cgn");
-#endif
 
 	int fid;
 	int fid_wrong = 9999;

--- a/unittests_cgnsfile/case_calccond.cpp
+++ b/unittests_cgnsfile/case_calccond.cpp
@@ -1,10 +1,6 @@
 #include "macros.h"
 
-#if defined(HAVE_QT)
-#include <QFile>
-#else
 #include "fs_copy.h"
-#endif
 
 #include <cgnslib.h>
 #include <iriclib.h>
@@ -22,11 +18,7 @@ extern "C" {
 void case_CalcCondRead()
 {
 	remove("case_cc.cgn");
-#if defined(HAVE_QT)
-        QFile::copy("case_init.cgn", "case_cc.cgn");
-#else
 	fs::copy("case_init.cgn", "case_cc.cgn");
-#endif
 
 	int fid;
 	int ier = cg_open("case_cc.cgn", CG_MODE_MODIFY, &fid);
@@ -160,11 +152,7 @@ void case_CalcCondRead()
 
 void case_CalcCondWrite()
 {
-#if defined(HAVE_QT)
-	QFile::copy("case_init.cgn", "case_ccwrite.cgn");
-#else
 	fs::copy("case_init.cgn", "case_ccwrite.cgn");
-#endif
 
 	int fid;
 	int ier = cg_open("case_ccwrite.cgn", CG_MODE_MODIFY, &fid);

--- a/unittests_cgnsfile/case_complex.cpp
+++ b/unittests_cgnsfile/case_complex.cpp
@@ -1,10 +1,6 @@
 #include "macros.h"
 
-#if defined(HAVE_QT)
-#include <QFile>
-#else
 #include "fs_copy.h"
-#endif
 
 #include <cgnslib.h>
 #include <iriclib.h>
@@ -20,11 +16,7 @@ extern "C" {
 
 void case_Complex()
 {
-#if defined(HAVE_QT)
-	QFile::copy("case_init.cgn", "case_complex.cgn");
-#else
 	fs::copy("case_init.cgn", "case_complex.cgn");
-#endif
 
 	int fid;
 	int ier = cg_open("case_complex.cgn", CG_MODE_MODIFY, &fid);

--- a/unittests_cgnsfile/case_grid.cpp
+++ b/unittests_cgnsfile/case_grid.cpp
@@ -1,10 +1,6 @@
 #include "macros.h"
 
-#if defined(HAVE_QT)
-#include <QFile>
-#else
 #include "fs_copy.h"
-#endif
 
 #include <cgnslib.h>
 #include <iriclib.h>
@@ -20,11 +16,7 @@ extern "C" {
 
 void case_GridRead()
 {
-#if defined(HAVE_QT)
-	QFile::copy("case_init.cgn", "case_grid.cgn");
-#else
 	fs::copy("case_init.cgn", "case_grid.cgn");
-#endif
 
 	int fid;
 	int ier = cg_open("case_grid.cgn", CG_MODE_MODIFY, &fid);
@@ -105,11 +97,7 @@ void case_GridRead()
 
 void case_GridReadFunc()
 {
-#if defined(HAVE_QT)
-	QFile::copy("case_gridfunc.cgn", "case_gridreadfunc.cgn");
-#else
 	fs::copy("case_gridfunc.cgn", "case_gridreadfunc.cgn");
-#endif
 
 	int fid;
 	int ier = cg_open("case_gridreadfunc.cgn", CG_MODE_MODIFY, &fid);
@@ -163,11 +151,7 @@ void case_GridReadFunc()
 
 void case_GridWrite()
 {
-#if defined(HAVE_QT)
-	QFile::copy("case_nogrid.cgn", "case_gridwrite1d.cgn");
-#else
 	fs::copy("case_nogrid.cgn", "case_gridwrite1d.cgn");
-#endif
 
 	int fid;
 	int ier = cg_open("case_gridwrite1d.cgn", CG_MODE_MODIFY, &fid);
@@ -220,11 +204,7 @@ void case_GridWrite()
 
 	remove("case_gridwrite1d.cgn");
 
-#if defined(HAVE_QT)
-	QFile::copy("case_nogrid.cgn", "case_gridwrite2d.cgn");
-#else
 	fs::copy("case_nogrid.cgn", "case_gridwrite2d.cgn");
-#endif
 
 	ier = cg_open("case_gridwrite2d.cgn", CG_MODE_MODIFY, &fid);
 
@@ -359,12 +339,7 @@ void case_GridWrite()
 
 	remove("case_gridwrite2d.cgn");
 
-#if defined(HAVE_QT)
-	QFile::copy("case_nogrid.cgn", "case_gridwrite3d.cgn");
-#else
 	fs::copy("case_nogrid.cgn", "case_gridwrite3d.cgn");
-#endif
-
 
 	ier = cg_open("case_gridwrite3d.cgn", CG_MODE_MODIFY, &fid);
 

--- a/unittests_cgnsfile/case_init.cpp
+++ b/unittests_cgnsfile/case_init.cpp
@@ -1,10 +1,6 @@
 #include "macros.h"
 
-#if defined(HAVE_QT)
-#include <QFile>
-#else
 #include "fs_copy.h"
-#endif
 
 #include <cgnslib.h>
 #include <iriclib.h>
@@ -16,11 +12,7 @@ extern "C" {
 void case_InitSuccess()
 {
 	remove("case_initsuccess.cgn");
-#if defined(HAVE_QT)
-	QFile::copy("case_init.cgn", "case_initsuccess.cgn");
-#else
 	fs::copy("case_init.cgn", "case_initsuccess.cgn");
-#endif
 
 	int fid;
 	int ier = cg_open("case_initsuccess.cgn", CG_MODE_MODIFY, &fid);

--- a/unittests_cgnsfile/case_initcc.cpp
+++ b/unittests_cgnsfile/case_initcc.cpp
@@ -1,10 +1,6 @@
 #include "macros.h"
 
-#if defined(HAVE_QT)
-#include <QFile>
-#else
 #include "fs_copy.h"
-#endif
 
 #include <cgnslib.h>
 #include <iriclib.h>
@@ -16,11 +12,7 @@ extern "C" {
 void case_InitCC()
 {
 	remove("case_initcc.cgn");
-#if defined(HAVE_QT)
-	QFile::copy("case_nogrid.cgn", "case_initcc.cgn");
-#else
 	fs::copy("case_nogrid.cgn", "case_initcc.cgn");
-#endif
 
 	int fid;
 	int ier = cg_open("case_nogrid.cgn", CG_MODE_MODIFY, &fid);

--- a/unittests_cgnsfile/case_initread.cpp
+++ b/unittests_cgnsfile/case_initread.cpp
@@ -1,10 +1,6 @@
 #include "macros.h"
 
-#if defined(HAVE_QT)
-#include <QFile>
-#else
 #include "fs_copy.h"
-#endif
 
 #include <cgnslib.h>
 #include <iriclib.h>
@@ -16,11 +12,7 @@ extern "C" {
 void case_InitReadSuccess()
 {
 	remove("case_initreadsuccess.cgn");
-#if defined(HAVE_QT)
-	QFile::copy("case_init.cgn", "case_initreadsuccess.cgn");
-#else
 	fs::copy("case_init.cgn", "case_initreadsuccess.cgn");
-#endif
 
 	int fid;
 	int ier = cg_open("case_initreadsuccess.cgn", CG_MODE_MODIFY, &fid);

--- a/unittests_cgnsfile/case_sol_readwrite.cpp
+++ b/unittests_cgnsfile/case_sol_readwrite.cpp
@@ -1,10 +1,6 @@
 #include "macros.h"
 
-#if defined(HAVE_QT)
-#include <QFile>
-#else
 #include "fs_copy.h"
-#endif
 
 #include <cgnslib.h>
 #include <iriclib.h>
@@ -226,11 +222,7 @@ void case_SolWriteStd()
 {
 	iRIC_InitOption(IRIC_OPTION_STDSOLUTION);
 
-#if defined(HAVE_QT)
-	QFile::copy("case_init.cgn", "case_solstd.cgn");
-#else
 	fs::copy("case_init.cgn", "case_solstd.cgn");
-#endif
 
 	int fid;
 	int ier = cg_open("case_solstd.cgn", CG_MODE_MODIFY, &fid);
@@ -263,11 +255,7 @@ void case_SolWriteStd()
 
 	// @todo add codes to test
 
-#if defined(HAVE_QT)
-	QFile::copy("case_init.cgn", "case_solstd3d.cgn");
-#else
 	fs::copy("case_init.cgn", "case_solstd3d.cgn");
-#endif
 
 	ier = cg_open("case_solstd3d.cgn", CG_MODE_MODIFY, &fid);
 	VERIFY_LOG("cg_open() ier == 0", ier == 0);
@@ -286,11 +274,7 @@ void case_SolWriteStd()
 
 	// @todo add codes to test
 
-#if defined(HAVE_QT)
-	QFile::copy("case_init.cgn", "case_solstditer.cgn");
-#else
 	fs::copy("case_init.cgn", "case_solstditer.cgn");
-#endif
 
 	ier = cg_open("case_solstditer.cgn", CG_MODE_MODIFY, &fid);
 	VERIFY_LOG("cg_open() ier == 0", ier == 0);
@@ -321,11 +305,7 @@ void case_SolWriteDivide()
 	remove("case_soldivide_Solution4.cgn");
 	remove("case_soldivide_Solution5.cgn");
 
-#if defined(HAVE_QT)
-	QFile::copy("case_init.cgn", "case_soldivide.cgn");
-#else
 	fs::copy("case_init.cgn", "case_soldivide.cgn");
-#endif
 
 	int fid;
 	int ier = cg_open("case_soldivide.cgn", CG_MODE_MODIFY, &fid);
@@ -370,11 +350,7 @@ void case_SolWriteDivide()
 
 	// @todo add codes to test
 
-#if defined(HAVE_QT)
-	QFile::copy("case_init.cgn", "case_soldivide3d.cgn");
-#else
 	fs::copy("case_init.cgn", "case_soldivide3d.cgn");
-#endif
 
 	ier = cg_open("case_soldivide3d.cgn", CG_MODE_MODIFY, &fid);
 	VERIFY_LOG("cg_open() ier == 0", ier == 0);

--- a/unittests_cgnsfile/case_sol_startend.cpp
+++ b/unittests_cgnsfile/case_sol_startend.cpp
@@ -1,9 +1,5 @@
 #include "macros.h"
 
-#if defined(HAVE_QT)
-#include <QFile>
-#endif
-
 #include <cgnslib.h>
 #include <iriclib.h>
 


### PR DESCRIPTION
Because we now has fs::copy(), I think code related to QFile::copy() is needless anymore.

Let's remove code related to QFile::copy(), to make the code more clean.
