### PR TITLE
Closes i-RIC/iriclib#42

### DIFF
--- a/iriclib.cpp
+++ b/iriclib.cpp
@@ -299,7 +299,18 @@ int iRIC_Check_Cancel()
 
 	if (result == 0){
 		// Getting information. succeeded. Cancel file exist.
-		return IRIC_CANCELED;
+		// Close all CGNS files.
+		for (int fid = 0; fid < m_files.size(); ++fid) {
+			iRICLib::CgnsFile* file = m_files[fid];
+			if (file == nullptr) {continue;}
+
+			delete file;
+			m_files[fid] = nullptr;
+			cg_close(fid);
+		}
+		// exits running
+		std::cout << "Solver is stopped because the STOP button was clicked." << std::endl;
+		exit(0);
 	}
 
 	// not canceled.

--- a/unittests_cgnsfile/case_check.cpp
+++ b/unittests_cgnsfile/case_check.cpp
@@ -16,14 +16,6 @@ void case_CheckLock()
 
 void case_CheckCancel()
 {
-	FILE* f = fopen(".cancel", "w");
-	fclose(f);
-
-	int canceled = iRIC_Check_Cancel();
-	VERIFY_LOG("iRIC_Check_Cancel() checked .cancel, and it existed.", canceled == 1);
-
-	remove(".cancel");
-
 	canceled = iRIC_Check_Cancel();
 	VERIFY_LOG("iRIC_Check_Cancel() checked .cancel, and it did not exist.", canceled == 0);
 }


### PR DESCRIPTION
As written in issue #42, When iRIC GUI creates ".cancel", `iRIC_Check_Cancel()` calls `exit(0)`. 
So I removed the unit test case to test calling `iRIC_Check_Cancel()` when ".cancel" exists.