### PR TITLE
Closes i-RIC/iriclib#56

### DIFF
--- a/iric_ftoc.c
+++ b/iric_ftoc.c
@@ -1157,6 +1157,45 @@ void IRICLIBDLL FMNAME(cg_iric_write_sol_particle_integer_mul_f, CG_IRIC_WRITE_S
 	*ier = cg_iRIC_Write_Sol_Particle_Integer_Mul(*fid, c_name, value);
 }
 
+void IRICLIBDLL FMNAME(cg_iric_write_sol_polydata_groupbegin_mul_f, CG_IRIC_WRITE_SOL_POLYDATA_GROUPBEGIN_MUL_F) (int *fid, STR_PSTR(name), int *ier STR_PLEN(name)) {
+	char c_name[CGIO_MAX_NAME_LENGTH+1];
+	string_2_C_string(STR_PTR(name), STR_LEN(name),
+		c_name, CGIO_MAX_NAME_LENGTH, ier);
+	if (*ier) return;
+
+	*ier = cg_iRIC_Write_Sol_PolyData_GroupBegin_Mul(*fid, c_name);
+}
+
+void IRICLIBDLL FMNAME(cg_iric_write_sol_polydata_groupend_mul_f, CG_IRIC_WRITE_SOL_POLYDATA_GROUPEND_MUL_F) (int *fid, int *ier) {
+	*ier = cg_iRIC_Write_Sol_PolyData_GroupEnd_Mul(*fid);
+}
+
+void IRICLIBDLL FMNAME(cg_iric_write_sol_polydata_polygon_mul_f, CG_IRIC_WRITE_SOL_POLYDATA_POLYGON_MUL_F) (int *fid, int *numPoints, double *x, double *y, int *ier) {
+	*ier = cg_iRIC_Write_Sol_PolyData_Polygon_Mul(*fid, *numPoints, x, y);
+}
+
+void IRICLIBDLL FMNAME(cg_iric_write_sol_polydata_polyline_mul_f, CG_IRIC_WRITE_SOL_POLYDATA_POLYLINE_MUL_F) (int *fid, int *numPoints, double *x, double *y, int *ier) {
+	*ier = cg_iRIC_Write_Sol_PolyData_Polyline_Mul(*fid, *numPoints, x, y);
+}
+
+void IRICLIBDLL FMNAME(cg_iric_write_sol_polydata_integer_mul_f, CG_IRIC_WRITE_SOL_POLYDATA_INTEGER_MUL_F) (int *fid, STR_PSTR(name), int *value, int *ier STR_PLEN(name)) {
+	char c_name[CGIO_MAX_NAME_LENGTH+1];
+	string_2_C_string(STR_PTR(name), STR_LEN(name),
+		c_name, CGIO_MAX_NAME_LENGTH, ier);
+	if (*ier) return;
+
+	*ier = cg_iRIC_Write_Sol_PolyData_Integer_Mul(*fid, c_name, *value);
+}
+
+void IRICLIBDLL FMNAME(cg_iric_write_sol_polydata_real_mul_f, CG_IRIC_WRITE_SOL_POLYDATA_REAL_MUL_F) (int *fid, STR_PSTR(name), double *value, int *ier STR_PLEN(name)) {
+	char c_name[CGIO_MAX_NAME_LENGTH+1];
+	string_2_C_string(STR_PTR(name), STR_LEN(name),
+		c_name, CGIO_MAX_NAME_LENGTH, ier);
+	if (*ier) return;
+
+	*ier = cg_iRIC_Write_Sol_PolyData_Real_Mul(*fid, c_name, *value);
+}
+
 void IRICLIBDLL FMNAME(cg_iric_read_geo_count_mul_f, CG_IRIC_READ_GEO_COUNT_MUL_F) (int *fid, STR_PSTR(name), int *count, int *ier STR_PLEN(name)) {
 	char c_name[CGIO_MAX_NAME_LENGTH+1];
 	string_2_C_string(STR_PTR(name), STR_LEN(name),
@@ -2304,6 +2343,45 @@ void IRICLIBDLL FMNAME(cg_iric_write_sol_particle_integer_f, CG_IRIC_WRITE_SOL_P
 	if (*ier) return;
 
 	*ier = cg_iRIC_Write_Sol_Particle_Integer(c_name, value);
+}
+
+void IRICLIBDLL FMNAME(cg_iric_write_sol_polydata_groupbegin_f, CG_IRIC_WRITE_SOL_POLYDATA_GROUPBEGIN_F) (STR_PSTR(name), int *ier STR_PLEN(name)) {
+	char c_name[CGIO_MAX_NAME_LENGTH+1];
+	string_2_C_string(STR_PTR(name), STR_LEN(name),
+		c_name, CGIO_MAX_NAME_LENGTH, ier);
+	if (*ier) return;
+
+	*ier = cg_iRIC_Write_Sol_PolyData_GroupBegin(c_name);
+}
+
+void IRICLIBDLL FMNAME(cg_iric_write_sol_polydata_groupend_f, CG_IRIC_WRITE_SOL_POLYDATA_GROUPEND_F) (int *ier) {
+	*ier = cg_iRIC_Write_Sol_PolyData_GroupEnd();
+}
+
+void IRICLIBDLL FMNAME(cg_iric_write_sol_polydata_polygon_f, CG_IRIC_WRITE_SOL_POLYDATA_POLYGON_F) (int *numPoints, double *x, double *y, int *ier) {
+	*ier = cg_iRIC_Write_Sol_PolyData_Polygon(*numPoints, x, y);
+}
+
+void IRICLIBDLL FMNAME(cg_iric_write_sol_polydata_polyline_f, CG_IRIC_WRITE_SOL_POLYDATA_POLYLINE_F) (int *numPoints, double *x, double *y, int *ier) {
+	*ier = cg_iRIC_Write_Sol_PolyData_Polyline(*numPoints, x, y);
+}
+
+void IRICLIBDLL FMNAME(cg_iric_write_sol_polydata_integer_f, CG_IRIC_WRITE_SOL_POLYDATA_INTEGER_F) (STR_PSTR(name), int *value, int *ier STR_PLEN(name)) {
+	char c_name[CGIO_MAX_NAME_LENGTH+1];
+	string_2_C_string(STR_PTR(name), STR_LEN(name),
+		c_name, CGIO_MAX_NAME_LENGTH, ier);
+	if (*ier) return;
+
+	*ier = cg_iRIC_Write_Sol_PolyData_Integer(c_name, *value);
+}
+
+void IRICLIBDLL FMNAME(cg_iric_write_sol_polydata_real_f, CG_IRIC_WRITE_SOL_POLYDATA_REAL_F) (STR_PSTR(name), double *value, int *ier STR_PLEN(name)) {
+	char c_name[CGIO_MAX_NAME_LENGTH+1];
+	string_2_C_string(STR_PTR(name), STR_LEN(name),
+		c_name, CGIO_MAX_NAME_LENGTH, ier);
+	if (*ier) return;
+
+	*ier = cg_iRIC_Write_Sol_PolyData_Real(c_name, *value);
 }
 
 void IRICLIBDLL FMNAME(cg_iric_read_geo_count_f, CG_IRIC_READ_GEO_COUNT_F) (STR_PSTR(name), int *count, int *ier STR_PLEN(name)) {

--- a/iriclib.cpp
+++ b/iriclib.cpp
@@ -1001,4 +1001,40 @@ int cg_iRIC_Write_Sol_Particle_Integer_Mul(int fid, const char* name, int* value
 	return f->Sol_Particle_Write_Integer(name, value);
 }
 
+int cg_iRIC_Write_Sol_PolyData_GroupBegin_Mul(int fid, const char* name)
+{
+	GET_F(fid);
+	return f->Sol_PolyData_Write_GroupBegin(name);
+}
+
+int cg_iRIC_Write_Sol_PolyData_GroupEnd_Mul(int fid)
+{
+	GET_F(fid);
+	return f->Sol_PolyData_Write_GroupEnd();
+}
+
+int cg_iRIC_Write_Sol_PolyData_Polygon_Mul(int fid, int numPoints, double* x, double* y)
+{
+	GET_F(fid);
+	return f->Sol_PolyData_Write_Polygon(numPoints, x, y);
+}
+
+int cg_iRIC_Write_Sol_PolyData_Polyline_Mul(int fid, int numPoints, double* x, double* y)
+{
+	GET_F(fid);
+	return f->Sol_PolyData_Write_Polyline(numPoints, x, y);
+}
+
+int cg_iRIC_Write_Sol_PolyData_Integer_Mul(int fid, const char* name, int value)
+{
+	GET_F(fid);
+	return f->Sol_PolyData_Write_Integer(name, value);
+}
+
+int cg_iRIC_Write_Sol_PolyData_Real_Mul(int fid, const char* name, double value)
+{
+	GET_F(fid);
+	return f->Sol_PolyData_Write_Real(name, value);
+}
+
 } // extern "C"

--- a/iriclib.h
+++ b/iriclib.h
@@ -16,6 +16,9 @@
 
 #define IRIC_CANCELED 1
 
+#define IRIC_POLYDATA_POLYGON  1
+#define IRIC_POLYDATA_POLYLINE 2
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -332,6 +335,17 @@ int IRICLIBDLL cg_iRIC_Write_Sol_Particle_Real_Mul(int fid, const char* name, do
 int IRICLIBDLL cg_iRIC_Write_Sol_Particle_Integer_Mul(int fid, const char* name, int* value);
 
 /**********************************************/
+/* Writing Polydata                           */
+/**********************************************/
+
+int IRICLIBDLL cg_iRIC_Write_Sol_PolyData_GroupBegin_Mul(int fid, const char* name);
+int IRICLIBDLL cg_iRIC_Write_Sol_PolyData_GroupEnd_Mul(int fid);
+int IRICLIBDLL cg_iRIC_Write_Sol_PolyData_Polygon_Mul(int fid, int numPoints, double* x, double* y);
+int IRICLIBDLL cg_iRIC_Write_Sol_PolyData_Polyline_Mul(int fid, int numPoints, double* x, double* y);
+int IRICLIBDLL cg_iRIC_Write_Sol_PolyData_Integer_Mul(int fid, const char* name, int value);
+int IRICLIBDLL cg_iRIC_Write_Sol_PolyData_Real_Mul(int fid, const char* name, double value);
+
+/**********************************************/
 /* Reading Geographic Data                    */
 /**********************************************/
 
@@ -633,6 +647,18 @@ int IRICLIBDLL cg_iRIC_Write_Sol_Particle_Pos3d(cgsize_t count, double* x, doubl
 int IRICLIBDLL cg_iRIC_Write_Sol_Particle_Real(const char* name, double* value);
 
 int IRICLIBDLL cg_iRIC_Write_Sol_Particle_Integer(const char* name, int* value);
+
+int IRICLIBDLL cg_iRIC_Write_Sol_PolyData_GroupBegin(const char* name);
+
+int IRICLIBDLL cg_iRIC_Write_Sol_PolyData_GroupEnd();
+
+int IRICLIBDLL cg_iRIC_Write_Sol_PolyData_Polygon(int numPoints, double* x, double* y);
+
+int IRICLIBDLL cg_iRIC_Write_Sol_PolyData_Polyline(int numPoints, double* x, double* y);
+
+int IRICLIBDLL cg_iRIC_Write_Sol_PolyData_Integer(const char* name, int value);
+
+int IRICLIBDLL cg_iRIC_Write_Sol_PolyData_Real(const char* name, double value);
 
 int IRICLIBDLL cg_iRIC_Read_Geo_Count(const char* name, int* count);
 

--- a/iriclib_cgnsfile.h
+++ b/iriclib_cgnsfile.h
@@ -189,6 +189,17 @@ public:
 	int Sol_Particle_Write_Real(const char* name, double* value);
 	int Sol_Particle_Write_Integer(const char* name, int* value);
 
+	// ----------------------
+	// Solution Polydata I/O
+	// ----------------------
+
+	int Sol_PolyData_Write_GroupBegin(const char* name);
+	int Sol_PolyData_Write_GroupEnd();
+	int Sol_PolyData_Write_Polygon(int numPoints, double* x, double* y);
+	int Sol_PolyData_Write_Polyline(int numPoints, double* x, double* y);
+	int Sol_PolyData_Write_Integer(const char* name, int value);
+	int Sol_PolyData_Write_Real(const char* name, double value);
+
 	// --------------------
 	// Geographic data I/O
 	// --------------------

--- a/iriclib_cgnsfile_base.cpp
+++ b/iriclib_cgnsfile_base.cpp
@@ -696,6 +696,11 @@ void CgnsFile::Impl::getParticleSolName(int num, char* name)
 	sprintf(name, "ParticleSolution%d", num);
 }
 
+void CgnsFile::Impl::getPolydataSolName(int num, char* name)
+{
+	sprintf(name, "PolydataSolution%d", num);
+}
+
 int CgnsFile::Impl::addSolutionNode(int fid, int bid, int zid, int sid, std::vector<std::string>* sols, std::vector<std::string>* cellsols)
 {
 	char solname[NAME_MAXLENGTH];
@@ -717,7 +722,13 @@ int CgnsFile::Impl::addSolutionNode(int fid, int bid, int zid, int sid, std::vec
 	ier = writeFlowSolutionPointers(fid, bid, zid, *sols);
 	RETURN_IF_ERR;
 
-	return writeFlowCellSolutionPointers(fid, bid, zid, *cellsols);
+	ier = writeFlowCellSolutionPointers(fid, bid, zid, *cellsols);
+	RETURN_IF_ERR;
+
+	ier = addPolydataSolutionNode(fid, bid, zid, sid);
+	RETURN_IF_ERR;
+
+	return 0;
 }
 
 int CgnsFile::Impl::addSolutionGridCoordNode(int fid, int bid, int zid, int sid, std::vector<std::string>* coords)
@@ -739,6 +750,16 @@ int CgnsFile::Impl::addParticleSolutionNode(int fid, int bid, int zid, int sid)
 {
 	char solname[NAME_MAXLENGTH];
 	getParticleSolName(sid, solname);
+
+	int ier = cg_goto(fid, bid, "Zone_t", zid, NULL);
+	RETURN_IF_ERR;
+	return cg_user_data_write(solname);
+}
+
+int CgnsFile::Impl::addPolydataSolutionNode(int fid, int bid, int zid, int sid)
+{
+	char solname[NAME_MAXLENGTH];
+	getPolydataSolName(sid, solname);
 
 	int ier = cg_goto(fid, bid, "Zone_t", zid, NULL);
 	RETURN_IF_ERR;

--- a/iriclib_cgnsfile_sol.cpp
+++ b/iriclib_cgnsfile_sol.cpp
@@ -258,3 +258,33 @@ int CgnsFile::Sol_Particle_Write_Integer(const char* name, int* value)
 {
 	return impl->m_solutionWriter->Sol_Particle_Write_Integer(name, value);
 }
+
+int CgnsFile::Sol_PolyData_Write_GroupBegin(const char* name)
+{
+	return impl->m_solutionWriter->Sol_PolyData_Write_GroupBegin(name);
+}
+
+int CgnsFile::Sol_PolyData_Write_GroupEnd()
+{
+	return impl->m_solutionWriter->Sol_PolyData_Write_GroupEnd();
+}
+
+int CgnsFile::Sol_PolyData_Write_Polygon(int numPoints, double* x, double* y)
+{
+	return impl->m_solutionWriter->Sol_PolyData_Write_Polygon(numPoints, x, y);
+}
+
+int CgnsFile::Sol_PolyData_Write_Polyline(int numPoints, double* x, double* y)
+{
+	return impl->m_solutionWriter->Sol_PolyData_Write_Polyline(numPoints, x, y);
+}
+
+int CgnsFile::Sol_PolyData_Write_Integer(const char* name, int value)
+{
+	return impl->m_solutionWriter->Sol_PolyData_Write_Integer(name, value);
+}
+
+int CgnsFile::Sol_PolyData_Write_Real(const char* name, double value)
+{
+	return impl->m_solutionWriter->Sol_PolyData_Write_Real(name, value);
+}

--- a/iriclib_f.h
+++ b/iriclib_f.h
@@ -17,3 +17,7 @@
 
       integer IRIC_CANCELED
       parameter(IRIC_CANCELED        = 1)
+      
+      integer IRIC_POLYDATA_POLYGON, IRIC_POLYDATA_POLYLINE
+      parameter(IRIC_POLYDATA_POLYGON  = 1)
+      parameter(IRIC_POLYDATA_POLYLINE = 2)

--- a/iriclib_single.c
+++ b/iriclib_single.c
@@ -597,6 +597,36 @@ int cg_iRIC_Write_Sol_Particle_Integer(const char* name, int* value)
 	return cg_iRIC_Write_Sol_Particle_Integer_Mul(lastfileid, name, value);
 }
 
+int cg_iRIC_Write_Sol_PolyData_GroupBegin(const char* name)
+{
+	return cg_iRIC_Write_Sol_PolyData_GroupBegin_Mul(lastfileid, name);
+}
+
+int cg_iRIC_Write_Sol_PolyData_GroupEnd()
+{
+	return cg_iRIC_Write_Sol_PolyData_GroupEnd_Mul(lastfileid);
+}
+
+int cg_iRIC_Write_Sol_PolyData_Polygon(int numPoints, double* x, double* y)
+{
+	return cg_iRIC_Write_Sol_PolyData_Polygon_Mul(lastfileid, numPoints, x, y);
+}
+
+int cg_iRIC_Write_Sol_PolyData_Polyline(int numPoints, double* x, double* y)
+{
+	return cg_iRIC_Write_Sol_PolyData_Polyline_Mul(lastfileid, numPoints, x, y);
+}
+
+int cg_iRIC_Write_Sol_PolyData_Integer(const char* name, int value)
+{
+	return cg_iRIC_Write_Sol_PolyData_Integer_Mul(lastfileid, name, value);
+}
+
+int cg_iRIC_Write_Sol_PolyData_Real(const char* name, double value)
+{
+	return cg_iRIC_Write_Sol_PolyData_Real_Mul(lastfileid, name, value);
+}
+
 int cg_iRIC_Read_Geo_Count(const char* name, int* count)
 {
 	return cg_iRIC_Read_Geo_Count_Mul(lastfileid, name, count);

--- a/private/iriclib_cgnsfile_impl.h
+++ b/private/iriclib_cgnsfile_impl.h
@@ -90,10 +90,12 @@ public:
 
 	static void getSolGridCoordName(int num, char* name);
 	static void getParticleSolName(int num, char* name);
+	static void getPolydataSolName(int num, char* name);
 
 	static int addSolutionNode(int fid, int bid, int zid, int sid, std::vector<std::string>* sols, std::vector<std::string>* cellsols);
 	static int addSolutionGridCoordNode(int fid, int bid, int zid, int sid, std::vector<std::string>* coords);
 	static int addParticleSolutionNode(int fid, int bid, int zid, int sid);
+	static int addPolydataSolutionNode(int fid, int bid, int zid, int sid);
 
 	static int writePointers(int fid, int bid, int zid, const char* name, const std::vector<std::string>& strs);
 	static int writeFlowSolutionPointers(int fid, int bid, int zid, const std::vector<std::string>& sols);
@@ -123,7 +125,6 @@ public:
 	std::vector<std::string> m_solPointers;
 	std::vector<std::string> m_cellSolPointers;
 	std::vector<std::string> m_solParticlePointers;
-
 
 	std::vector<BaseIterativeT<int> > m_solBaseIterInts;
 	std::vector<BaseIterativeT<double> > m_solBaseIterReals;

--- a/private/iriclib_cgnsfile_solutionwriter.cpp
+++ b/private/iriclib_cgnsfile_solutionwriter.cpp
@@ -1,3 +1,6 @@
+#include "error_macros.h"
+#include "iriclib.h"
+#include "iriclib_cgnsfile_impl.h"
 #include "iriclib_cgnsfile_solutionwriter.h"
 
 using namespace iRICLib;
@@ -9,7 +12,131 @@ CgnsFile::SolutionWriter::SolutionWriter(CgnsFile::Impl *impl) :
 CgnsFile::SolutionWriter::~SolutionWriter()
 {}
 
+int CgnsFile::SolutionWriter::Sol_PolyData_Write_GroupBegin(const char* name)
+{
+	clearPolyData();
+	m_polydataName = name;
+	return 0;
+}
+
+int CgnsFile::SolutionWriter::Sol_PolyData_Write_Polygon(int num, double* x, double* y)
+{
+	m_polydataTypes.push_back(IRIC_POLYDATA_POLYGON);
+	m_polydataSizes.push_back(num);
+	for (int i = 0; i < num; ++i) {
+		m_polydataX.push_back(*(x + i));
+		m_polydataY.push_back(*(y + i));
+	}
+	return 0;
+}
+
+int CgnsFile::SolutionWriter::Sol_PolyData_Write_Polyline(int num, double* x, double* y)
+{
+	m_polydataTypes.push_back(IRIC_POLYDATA_POLYLINE);
+	m_polydataSizes.push_back(num);
+	for (int i = 0; i < num; ++i) {
+		m_polydataX.push_back(*(x + i));
+		m_polydataY.push_back(*(y + i));
+	}
+	return 0;
+}
+
+template<typename V>
+int SolPolyDataAddValue(const char* name, V value, std::map<std::string, std::vector<V> >* vals)
+{
+	std::string namestr = name;
+	auto it = vals->find(namestr);
+	if (it == vals->end()) {
+		std::vector<V> emptyVec;
+		vals->insert({namestr, emptyVec});
+		it = vals->find(namestr);
+	}
+	auto& vec = it->second;
+	vec.push_back(value);
+	return 0;
+}
+
+int CgnsFile::SolutionWriter::Sol_PolyData_Write_Integer(const char* name, int value)
+{
+	return SolPolyDataAddValue(name, value, &m_polydataIntValues);
+}
+
+int CgnsFile::SolutionWriter::Sol_PolyData_Write_Real(const char* name, double value)
+{
+	return SolPolyDataAddValue(name, value, &m_polydataRealValues);
+}
+
 CgnsFile::Impl* CgnsFile::SolutionWriter::impl() const
 {
 	return m_impl;
+}
+
+int CgnsFile::SolutionWriter::stdSolPolyDataGroupEnd(int fid, int bid, int zid, int sid)
+{
+	char name[Impl::NAME_MAXLENGTH];
+	Impl::getPolydataSolName(sid, name);
+	int ier = cg_goto(fid, bid, "Zone_t", zid, name, 0, NULL);
+	RETURN_IF_ERR;
+
+	std::string arrayName;
+
+	// write type
+	arrayName = m_polydataName;
+	arrayName.append("_type");
+	ier = Impl::writeArray(arrayName.c_str(), Integer, m_polydataTypes.size(), m_polydataTypes.data());
+	RETURN_IF_ERR;
+
+	// write size
+	arrayName = m_polydataName;
+	arrayName.append("_size");
+	ier = Impl::writeArray(arrayName.c_str(), Integer, m_polydataSizes.size(), m_polydataSizes.data());
+	RETURN_IF_ERR;
+
+	// write X
+	arrayName = m_polydataName;
+	arrayName.append("_coordinateX");
+	ier = Impl::writeArray(arrayName.c_str(), RealDouble, m_polydataX.size(), m_polydataX.data());
+	RETURN_IF_ERR;
+
+	// write Y
+	arrayName = m_polydataName;
+	arrayName.append("_coordinateY");
+	ier = Impl::writeArray(arrayName.c_str(), RealDouble, m_polydataY.size(), m_polydataY.data());
+	RETURN_IF_ERR;
+
+	// write int values
+	for (auto& pair : m_polydataIntValues) {
+		auto valueName = pair.first;
+		auto& values = pair.second;
+
+		arrayName = m_polydataName;
+		arrayName.append("__");
+		arrayName.append(valueName);
+		ier = Impl::writeArray(arrayName.c_str(), Integer, values.size(), values.data());
+		RETURN_IF_ERR;
+	}
+
+	// write real values
+	for (auto& pair : m_polydataRealValues) {
+		auto valueName = pair.first;
+		auto& values = pair.second;
+
+		arrayName = m_polydataName;
+		arrayName.append("__");
+		arrayName.append(valueName);
+		ier = Impl::writeArray(arrayName.c_str(), RealDouble, values.size(), values.data());
+		RETURN_IF_ERR;
+	}
+	return 0;
+}
+
+void CgnsFile::SolutionWriter::clearPolyData()
+{
+	m_polydataName.clear();
+	m_polydataTypes.clear();
+	m_polydataSizes.clear();
+	m_polydataX.clear();
+	m_polydataY.clear();
+	m_polydataIntValues.clear();
+	m_polydataRealValues.clear();
 }

--- a/private/iriclib_cgnsfile_solutionwriter.h
+++ b/private/iriclib_cgnsfile_solutionwriter.h
@@ -3,6 +3,10 @@
 
 #include "../iriclib_cgnsfile.h"
 
+#include <map>
+#include <string>
+#include <vector>
+
 namespace iRICLib {
 
 class CgnsFile::SolutionWriter
@@ -23,11 +27,27 @@ public:
 	virtual int Sol_Particle_Write_Pos3d(cgsize_t count, double* x, double* y, double* z) = 0;
 	virtual int Sol_Particle_Write_Real(const char* name, double* value) = 0;
 	virtual int Sol_Particle_Write_Integer(const char* name, int* value) = 0;
+	int Sol_PolyData_Write_GroupBegin(const char* name);
+	virtual int Sol_PolyData_Write_GroupEnd() = 0;
+	int Sol_PolyData_Write_Polygon(int num, double* x, double* y);
+	int Sol_PolyData_Write_Polyline(int num, double* x, double* y);
+	int Sol_PolyData_Write_Integer(const char* name, int value);
+	int Sol_PolyData_Write_Real(const char* name, double value);
 
 	virtual int Flush() = 0;
 
 protected:
 	CgnsFile::Impl* impl() const;
+	int stdSolPolyDataGroupEnd(int fid, int bid, int zid, int sid);
+	void clearPolyData();
+
+	std::string m_polydataName;
+	std::vector<int> m_polydataTypes;
+	std::vector<int> m_polydataSizes;
+	std::vector<double> m_polydataX;
+	std::vector<double> m_polydataY;
+	std::map<std::string, std::vector<int> > m_polydataIntValues;
+	std::map<std::string, std::vector<double> > m_polydataRealValues;
 
 private:
 	CgnsFile::Impl* m_impl;

--- a/private/iriclib_cgnsfile_solutionwriterdividesolutions.cpp
+++ b/private/iriclib_cgnsfile_solutionwriterdividesolutions.cpp
@@ -310,6 +310,11 @@ int CgnsFile::SolutionWriterDivideSolutions::Sol_Particle_Write_Integer(const ch
 	return SolutionWriterStandard::stdSolParticleWriteInteger(name, value, m_fileId, m_baseId, m_zoneId, 1);
 }
 
+int CgnsFile::SolutionWriterDivideSolutions::Sol_PolyData_Write_GroupEnd()
+{
+	return stdSolPolyDataGroupEnd(m_fileId, m_baseId, m_zoneId, 1);
+}
+
 int CgnsFile::SolutionWriterDivideSolutions::Flush()
 {
 	return closeFileIfOpen();

--- a/private/iriclib_cgnsfile_solutionwriterdividesolutions.h
+++ b/private/iriclib_cgnsfile_solutionwriterdividesolutions.h
@@ -25,6 +25,7 @@ public:
 	int Sol_Particle_Write_Pos3d(cgsize_t count, double* x, double* y, double* z) override;
 	int Sol_Particle_Write_Real(const char* name, double* value) override;
 	int Sol_Particle_Write_Integer(const char* name, int* value) override;
+	int Sol_PolyData_Write_GroupEnd() override;
 
 	int Flush() override;
 

--- a/private/iriclib_cgnsfile_solutionwriterstandard.cpp
+++ b/private/iriclib_cgnsfile_solutionwriterstandard.cpp
@@ -98,6 +98,12 @@ int CgnsFile::SolutionWriterStandard::Sol_Particle_Write_Integer(const char* nam
 	return stdSolParticleWriteInteger(name, value, i->m_fileId, i->m_baseId, i->m_zoneId, i->m_solId);
 }
 
+int CgnsFile::SolutionWriterStandard::Sol_PolyData_Write_GroupEnd()
+{
+	Impl* i = impl();
+	return stdSolPolyDataGroupEnd(i->m_fileId, i->m_baseId, i->m_zoneId, i->m_solId);
+}
+
 int CgnsFile::SolutionWriterStandard::Flush()
 {
 	return 0;

--- a/private/iriclib_cgnsfile_solutionwriterstandard.h
+++ b/private/iriclib_cgnsfile_solutionwriterstandard.h
@@ -23,6 +23,7 @@ public:
 	int Sol_Particle_Write_Pos3d(cgsize_t count, double* x, double* y, double* z) override;
 	int Sol_Particle_Write_Real(const char* name, double* value) override;
 	int Sol_Particle_Write_Integer(const char* name, int* value) override;
+	int Sol_PolyData_Write_GroupEnd() override;
 
 	int Flush() override;
 


### PR DESCRIPTION
This pull requests will add functions below:
* cg_iRIC_Write_Sol_PolyData_GroupBegin
* cg_iRIC_Write_Sol_PolyData_GroupEnd
* cg_iRIC_Write_Sol_PolyData_Polygon
* cg_iRIC_Write_Sol_PolyData_Polyline
* cg_iRIC_Write_Sol_PolyData_Integer
* cg_iRIC_Write_Sol_PolyData_Real

These functions can be used to output polygons and polylines as calculation results.

The sample solver source code and the CGNS file created with the sample solver is attached to this pull request.

Using ADFViewer, you can check that fish_xxx, driftwood_xxx data is output to /iRIC/iRICZone/PolydataSolutionX folders in the CGNS file.

I'm going to send a pull request on i-RIC/prepost-gui, that will make it possible to visualize the polygon and polyline data on 2D post-processor window soon.

Thanks,
Keisuke

[issue-56.zip](https://github.com/i-RIC/iriclib/files/2975931/issue-56.zip)
